### PR TITLE
[CHAT-338] Don't hard code the api version in the framework

### DIFF
--- a/index.js
+++ b/index.js
@@ -144,7 +144,7 @@ class TestingFramework {
     }
 
     _send(spec, sender, message) {
-        const channelUrl = `${this._apiUrl}v1/bots/${spec.proxyBotId || spec.botId}/channels/${spec.channel.id}/darvin`;
+        const channelUrl = `${this._apiUrl}/bots/${spec.proxyBotId || spec.botId}/channels/${spec.channel.id}/darvin`;
         const payload = {
             sender,
             message

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "darvin-testing-framework",
-  "version": "1.13.1",
+  "version": "2.0.0",
   "description": "A framework for testing Kinvey Chat bots.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
# Purpose

We should provide the ability to test against versions other than v1.

Since we are not going to assume the api version,
this is a breaking change, we need to publish v2 of the package.